### PR TITLE
Add more info to invoice paid and order paid

### DIFF
--- a/includes/hooks/WHMCS-Discord-Notifications.php
+++ b/includes/hooks/WHMCS-Discord-Notifications.php
@@ -88,7 +88,6 @@ if($invoicePaid === true):
 			'content' => $GLOBALS['discordGroupID'],
 			'username' => $GLOBALS['companyName'],
 			'avatar_url' => $GLOBALS['discordWebHookAvatar'],
-			// Create a pretty embed showing the email of the user who paid as well as the amount of paid. Include each product in the order as an inline field
 			'embeds' => array(
 				array(
 					'title' => 'Invoice ' . $vars['invoiceid'] . ' Has Been Paid',


### PR DESCRIPTION
This adds some more info to the invoice paid and order paid embeds to include the email of the client who paid them and the amount paid. It also includes the products purchased in the case of orders paid.


This also fixes #13, a bug which existed surrounding the order id not properly showing in the orderpaid embed.